### PR TITLE
remove liblld-13-dev again

### DIFF
--- a/.github/workflows/cmake-m.yml
+++ b/.github/workflows/cmake-m.yml
@@ -27,12 +27,11 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    # ld.cc requires liblld-13-dev
     - name: Install LLVM & LLD
       run: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
-        sudo apt-get install llvm-13 lld-13 clang-13 liblld-13-dev
+        sudo apt-get install llvm-13 lld-13 clang-13
         sudo ln /usr/bin/llvm-config-13 /usr/bin/llvm-config
         sudo ln /usr/bin/llvm-ar-13 /usr/bin/llvm-ar
         sudo ln /usr/bin/llvm-nm-13 /usr/bin/llvm-nm

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -64,7 +64,7 @@ link_directories(
 )
 
 add_executable(m
-  driver/ld.cc
+  driver/ld.c
   driver/m.cc
 )
 
@@ -77,17 +77,18 @@ set_target_properties(m PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(m PRIVATE 
   mlrl
   clib
-  lldDriver
-  lldCOFF
-  lldELF
-  lldMachO
-  lldMachO2
-  lldMinGW
-  lldWasm
-  lldYAML
-  lldReaderWriter
-  lldCommon
-  lldCore
+  # LD dependencies
+  # lldDriver
+  # lldCOFF
+  # lldELF
+  # lldMachO
+  # lldMachO2
+  # lldMinGW
+  # lldWasm
+  # lldYAML
+  # lldReaderWriter
+  # lldCommon
+  # lldCore
   ${llvm_libfiles}
   ${sys_libraries}
 )

--- a/apps/driver/ld.c
+++ b/apps/driver/ld.c
@@ -1,0 +1,3 @@
+int ld(int argc, const char **argv) {
+  return 0;
+}

--- a/include/compiler/ld.h
+++ b/include/compiler/ld.h
@@ -1,1 +1,21 @@
+/*
+ * ld.h
+ * 
+ * Copyright (C) 2023 Ligang Wang <ligangwangs@gmail.com>
+ *
+ * interface header file invoking ld linker
+ */
+#ifndef __COMPILER_LD_H__
+#define __COMPILER_LD_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int ld(int argc, const char **argv);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
trying to remove liblld-13-dev dependency, we should rely on LD/LLD binary file installed in the system to provide linking function